### PR TITLE
[Refactor][온보딩] 반응테스트 스크린 qa 적용

### DIFF
--- a/src/components/emoticons/TestIconButton.tsx
+++ b/src/components/emoticons/TestIconButton.tsx
@@ -19,12 +19,12 @@ const TestIconButton = ({ xml }: TestIconButtonProps) => {
     setAnimate((prev) => [...prev, `${xml}${animate.length}`]);
     Animated.timing(opacityValue, {
       toValue: 1,
-      duration: 750,
+      duration: 0,
       useNativeDriver: false,
     }).start(() => {
       Animated.timing(opacityValue, {
         toValue: 0,
-        duration: 0,
+        duration: 750,
         useNativeDriver: false,
       }).start();
     });
@@ -37,7 +37,7 @@ const TestIconButton = ({ xml }: TestIconButtonProps) => {
           style={{
             backgroundColor: opacityValue.interpolate({
               inputRange: [0, 1],
-              outputRange: ['#00000000', theme.colors.brand.surface.main],
+              outputRange: ['#00000000', '#1213140d'],
             }),
             padding: 10,
             ...styles.Button,

--- a/src/components/header/HeaderRightButton.tsx
+++ b/src/components/header/HeaderRightButton.tsx
@@ -61,7 +61,6 @@ const styles = StyleSheet.create({
   btn: {
     padding: 0,
     borderRadius: 30,
-    borderColor: 'black',
   },
   text: {
     fontWeight: '600',

--- a/src/screens/onboarding/InsightSampleScreen.tsx
+++ b/src/screens/onboarding/InsightSampleScreen.tsx
@@ -76,21 +76,22 @@ const InsightSampleScreen = ({ navigation, route }) => {
             style={{
               height: 90,
               justifyContent: 'space-between',
-              marginBottom: 20,
+              marginBottom: 32,
             }}
           >
             <HeaderText
               header={`키위새님,\n이 인사이트 어때요?`}
-              subTitle={'인사이트를 읽고 반응을 남겨보세요!'}
+              subTitle={'인사이트를 읽고 반응을 눌러보세요!'}
             />
           </View>
-          <ScrollView
+          <View
             style={{
-              backgroundColor: theme.colors.brand.surface.container,
-              height: 300,
+              backgroundColor: theme.colors.brand.surface.container1,
               marginLeft: 10,
               marginRight: 10,
-              borderRadius: 10,
+              paddingHorizontal: 16,
+              paddingVertical: 20,
+              borderRadius: 12,
             }}
           >
             <View style={styles.Insight}>
@@ -102,7 +103,7 @@ const InsightSampleScreen = ({ navigation, route }) => {
                   <Pressable
                     onPress={handleMoreClick}
                     style={{
-                      backgroundColor: theme.colors.brand.surface.container,
+                      backgroundColor: theme.colors.brand.surface.container1,
                       ...styles.MoreLink,
                     }}
                   >
@@ -129,7 +130,7 @@ const InsightSampleScreen = ({ navigation, route }) => {
                 </Text>
               </Pressable>
             </View>
-          </ScrollView>
+          </View>
           {reaction ? (
             <>
               <View style={styles.React}>
@@ -206,14 +207,13 @@ const styles = StyleSheet.create({
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'space-between',
-    margin: 25,
   },
   LinkTitle: {
     display: 'flex',
     flexDirection: 'row',
     alignContent: 'center',
     alignItems: 'center',
-    marginBottom: 5,
+    marginBottom: 16,
   },
   ReactionBar: {
     display: 'flex',

--- a/src/screens/onboarding/constant.ts
+++ b/src/screens/onboarding/constant.ts
@@ -7,8 +7,8 @@ import SurpriseRoundOffXml from '../../constants/Icons/Reacts/SurpriseRoundOffXm
 import theme from '../../theme/light';
 
 export const REACTIONS: Record<string, any>[] = [
-  { xml: ClapRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.0] },
-  { xml: HeartRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.12] },
+  { xml: HeartRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.0] },
+  { xml: ClapRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.12] },
   { xml: SadRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.24] },
   { xml: SurpriseRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.36] },
   { xml: EyesRoundOffXml, bezier: [0.5, 1.8, 0.4, 1.48] },


### PR DESCRIPTION
##Refactor
- [x]  헤드라인 아래 텍스트 “남겨보세요” → “눌러보세요” 로 수정
- [x]  헤드라인+디스크립션 텍스트(”인사이트를 읽고~눌러보세요!”텍스트까지)영역과 카드 사이 간격 32px
- [x]  인사이트 카드 border-radius: 12px; 로 수정
- [x]  인사이트 카드 패딩 padding: 16px 20px; 로 수정
- [x]  인사이트 카드 색상 neutral/surface-container1(#F1F1E9)로 수정
- [x]  텍스트와 하단 링크 사이 간격 16px로 수정

**2**

- [x]  더보기 누르면 카드 내부에 스크롤이 생기는 것이 아닌, 카드 높이 자체가 길어져야 함. 피그마 참고[[https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/키위-Keewe?node-id=3207%3A49774&t=XGOzCRpAmrlw1K6m-4](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3207%3A49774&t=XGOzCRpAmrlw1K6m-4)](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=3207%3A49774&t=XGOzCRpAmrlw1K6m-4)

**3**

- [x]  아이콘 눌릴 때 색상 background: rgba(18, 19, 20, 0.05); 로 수정
- [x]  반응 아이콘 순서 피그마와 같이 수정 [[https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/키위-Keewe?node-id=2935%3A45618&t=XGOzCRpAmrlw1K6m-4](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=2935%3A45618&t=XGOzCRpAmrlw1K6m-4)](https://www.figma.com/file/myrpWyrITG5YM9o9I5Ems7/%ED%82%A4%EC%9C%84-Keewe?node-id=2935%3A45618&t=XGOzCRpAmrlw1K6m-4)