### PR TITLE
[Fix][DetailedPost] 챌린지 기록 정보 없을 시 null/null 으로 보이는 현상 수정

### DIFF
--- a/src/screens/detailedPost/DetailedPostScreen.tsx
+++ b/src/screens/detailedPost/DetailedPostScreen.tsx
@@ -2,6 +2,7 @@
 import {
   Pressable,
   ScrollView,
+  RefreshControl,
   StyleSheet,
   View,
   Text,
@@ -170,6 +171,16 @@ const DetailedPostScreen = ({ navigation, route }) => {
     surprise: 45,
   };
 
+  const recordOrder = getChallengeRecordResponse?.data?.order;
+  const recordTotal = getChallengeRecordResponse?.data?.total;
+  
+  let recordText;
+  if(recordOrder && recordTotal) {
+    recordText = `${recordOrder}/${recordTotal}번째 기록중`;
+  } else {
+    recordText = '';
+  }
+
   return (
     <>
       <KeyboardAvoidingView
@@ -192,7 +203,7 @@ const DetailedPostScreen = ({ navigation, route }) => {
               currentChallenge={getChallengeRecordResponse?.data?.challengeName}
               reaction={insightResponse.data.reaction}
               authorId={profile?.data?.authorId ?? -1}
-              recordText={`${getChallengeRecordResponse?.data?.order}/${getChallengeRecordResponse?.data?.total}번째 기록중`}
+              recordText={recordText}
             />
           ) : (
             <DetailedPostSection

--- a/src/screens/detailedPost/DetailedPostScreen.tsx
+++ b/src/screens/detailedPost/DetailedPostScreen.tsx
@@ -119,6 +119,9 @@ const DetailedPostScreen = ({ navigation, route }) => {
     () => InsightAPI.getChallengeRecord({ insightId }),
   );
 
+  const recordOrder = getChallengeRecordResponse?.data?.order;
+  const recordTotal = getChallengeRecordResponse?.data?.total;
+
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => {
@@ -171,16 +174,6 @@ const DetailedPostScreen = ({ navigation, route }) => {
     surprise: 45,
   };
 
-  const recordOrder = getChallengeRecordResponse?.data?.order;
-  const recordTotal = getChallengeRecordResponse?.data?.total;
-  
-  let recordText;
-  if(recordOrder && recordTotal) {
-    recordText = `${recordOrder}/${recordTotal}번째 기록중`;
-  } else {
-    recordText = '';
-  }
-
   return (
     <>
       <KeyboardAvoidingView
@@ -203,7 +196,7 @@ const DetailedPostScreen = ({ navigation, route }) => {
               currentChallenge={getChallengeRecordResponse?.data?.challengeName}
               reaction={insightResponse.data.reaction}
               authorId={profile?.data?.authorId ?? -1}
-              recordText={recordText}
+              recordText={recordOrder && recordTotal ? `${recordOrder}/${recordTotal}번째 기록중` : ''}
             />
           ) : (
             <DetailedPostSection
@@ -213,10 +206,10 @@ const DetailedPostScreen = ({ navigation, route }) => {
               insightText={''}
               views={views}
               url={''}
-              currentChallenge={'temp'}
+              currentChallenge={''}
               reaction={tempReaction}
               authorId={profile?.data?.authorId ?? -1}
-              recordText={'temp record Text'}
+              recordText={''}
             />
             // <View>
             //   <Text>temp</Text>

--- a/src/screens/detailedPost/DetailedPostScreen.tsx
+++ b/src/screens/detailedPost/DetailedPostScreen.tsx
@@ -2,7 +2,6 @@
 import {
   Pressable,
   ScrollView,
-  RefreshControl,
   StyleSheet,
   View,
   Text,


### PR DESCRIPTION
### [기록 있을 때]
<img width="381" alt="스크린샷 2023-04-23 오후 7 48 54" src="https://user-images.githubusercontent.com/33655186/233835443-fb8a7f70-3049-48e8-b4ca-04520db214f4.png">


### [없을 때]
<img width="397" alt="image" src="https://user-images.githubusercontent.com/33655186/233835474-7396dc50-eb7e-4d3f-931c-728931394d14.png">

