### PR TITLE
[Fix][FeedScreen] 챌린지 미참여중일 때 Divide bar 제거

### DIFF
--- a/src/components/challenge/FeedScreenChallenge.tsx
+++ b/src/components/challenge/FeedScreenChallenge.tsx
@@ -22,7 +22,7 @@ const FeedScreenChallenge = () => {
           <UserSpecificChallengeSection userSpecificChallenge={userSpecificChallenge} />
         )}
       </View>
-      <DividerBar style={styles.divider} />
+      {userSpecificChallenge && <DividerBar style={styles.divider} />}
     </>
   );
 };


### PR DESCRIPTION
# Fix
챌린지 미참여중일 때도 divide bar가 존재하여 눈에 거슬려서 제거해요