### PR TITLE
[Fix][QA] tiny issues

### DIFF
--- a/src/components/texts/CountingTextArea.tsx
+++ b/src/components/texts/CountingTextArea.tsx
@@ -55,7 +55,7 @@ const CountingTextArea = (props: CountingTextAreaProps) => {
       >
         <TextInput
           // BUG: making TextInput a controlled component causes it to make unexpected cursor jumps and duplicate characters.
-          // value={inputValue}
+          value={inputValue}
           autoFocus={autoFocus}
           placeholder={placeholder}
           onChangeText={(text) => setInputValue(text)}

--- a/src/components/texts/CountingTextArea.tsx
+++ b/src/components/texts/CountingTextArea.tsx
@@ -10,6 +10,7 @@ interface CountingTextAreaProps {
   limit?: number;
   style?: any;
   height?: any;
+  textInputMarginBottom?: number;
   autoFocus?: boolean;
   limitTextStyle?: any;
   multiline?: boolean;
@@ -24,6 +25,7 @@ const CountingTextArea = (props: CountingTextAreaProps) => {
     style,
     limit,
     height,
+    textInputMarginBottom,
     autoFocus = false,
     multiline,
   } = props;
@@ -45,14 +47,22 @@ const CountingTextArea = (props: CountingTextAreaProps) => {
           </Text>
         </View>
       )}
-      <View style={{ ...styles.intro, height: height ?? 140 }}>
+      <View
+        style={{
+          ...styles.intro,
+          height: height ?? 140,
+        }}
+      >
         <TextInput
           // BUG: making TextInput a controlled component causes it to make unexpected cursor jumps and duplicate characters.
           // value={inputValue}
           autoFocus={autoFocus}
           placeholder={placeholder}
           onChangeText={(text) => setInputValue(text)}
-          style={styles.input}
+          style={{
+            ...styles.input,
+            marginBottom: textInputMarginBottom || 22,
+          }}
           // multiline sets texts ios to top, android to center.
           // needs textAlignVertical to top on android
           multiline={multiline ?? true}
@@ -86,7 +96,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     backgroundColor: 'white',
     marginHorizontal: 16,
-    marginBottom: 22,
     marginTop: 10,
     fontSize: 16,
     height: '100%',

--- a/src/screens/Main/mypage/IntroductionEditingScreen.tsx
+++ b/src/screens/Main/mypage/IntroductionEditingScreen.tsx
@@ -6,7 +6,7 @@ import CountingTextArea from '../../../components/texts/CountingTextArea';
 
 const IntroductionEditingScreen = ({ navigation, route }) => {
   const theme = useTheme();
-  const [input, setInput] = useState<string>('');
+  const [input, setInput] = useState<string>(route?.params?.introduction);
   const [nickname] = useState(route?.params?.nickname);
   const [image] = useState(route?.params?.image);
   const [title] = useState(route?.params?.title);
@@ -53,8 +53,8 @@ const IntroductionEditingScreen = ({ navigation, route }) => {
   }, [input]);
 
   useEffect(() => {
-    setInput(route.params?.introduction ?? '');
-  }, [route.params]);
+    setInput(route?.params?.introduction ?? '');
+  }, [route]);
 
   return (
     <View style={styles.container}>

--- a/src/screens/upload/LinkSheetContent.tsx
+++ b/src/screens/upload/LinkSheetContent.tsx
@@ -49,6 +49,7 @@ const LinkSheetContent = ({
         autoFocus={true}
         limitTextStyle={{ color: 'white' }}
         multiline={false}
+        textInputMarginBottom={80}
       />
     </View>
   );


### PR DESCRIPTION
## Fix

- IOS 상에서만 업로드 링크 창의 커서 위치가 center에 위치하는 현상 수정
- 프로필 소개글 수정 시, 기존 소개글이 디폴트가 되지 않고 비어있는 현상이 발생하였는데, 원인은 지난 QA 중, 업로드 링크창 커서가 춤추듯 이상한 행동을 보이는 이슈 디버깅을 위해 CountingTextArea의 inputValue 프로퍼티를 주석처리 해놓은 것에 대한 풍선효과였음. 그래서 결과적으로 주석 처리를 풀었는데, 이번엔 업로드 링크 커서가 춤을 추지 않아서 이대로 푸쉬함.