### PR TITLE
[Fix][온보딩] 온보딩시에, 관심사 추가하면 닉네임이 undefined로 변하는 버그 수정

### DIFF
--- a/src/screens/Main/challenge/ChallengeParticipationScreen.tsx
+++ b/src/screens/Main/challenge/ChallengeParticipationScreen.tsx
@@ -13,7 +13,6 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { useGetUserId } from '../../../utils/hooks/useGetUserId';
 
 const ChallengeParticipationScreen = ({ route }) => {
-  const userId = useGetUserId();
   const { challengeId } = route.params;
   const [modalVisible, setModalVisible] = useState<boolean>(false);
 
@@ -105,7 +104,7 @@ const ChallengeParticipationScreen = ({ route }) => {
                 return (
                   <ChallengeUserProfile
                     key={idx}
-                    userId={userId ?? 0}
+                    userId={item.userId}
                     nickname={item.nickname}
                     imageURL={item.imageURL}
                     currentRecord={item.currentRecord}

--- a/src/screens/onboarding/InterestChooseScreen.tsx
+++ b/src/screens/onboarding/InterestChooseScreen.tsx
@@ -16,15 +16,17 @@ const InterestChooseScreen = ({ navigation, route }) => {
   const [customCategory, setCustomCategory] = useState<string[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
   const [conditionalText, setConditionalText] = useState<string>('관심사를 선택하세요');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [nicknameState, _] = useState<string>(route.params.nickname);
 
   const { mutate: makeProfile } = useMutation(
     OnboardQueryKeys.makeProfile({
-      nickname: route.params.nickname,
+      nickname: nicknameState,
       interests: selectedCategory,
     }),
     () =>
       OnboardAPI.makeProfile({
-        nickname: route.params.nickname,
+        nickname: nicknameState,
         interests: selectedCategory,
       }),
   );


### PR DESCRIPTION
## Fix
* route.params.nickname을 state로 저장하게끔 하여, 네비게이션에 잃어버리지 않게끔 함. 
* 미참여중인 챌린지에서, 타 프로필을 프레스시에 자기의 프로필화면으로 넘어가는 버그 고침